### PR TITLE
Change to have only one volume for www

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Maxime Junger <maxime.junger@epitech.eu>
 
 RUN apk add --update nginx && rm -rf /var/cache/apk/*
 
-VOLUME ["/etc/nginx/sites-enabled", "/etc/nginx/certs", "/etc/nginx/conf.d", "/var/log/nginx", "/var/www/html", "/var/www/404/"]
+VOLUME ["/etc/nginx/sites-enabled", "/etc/nginx/certs", "/etc/nginx/conf.d", "/var/log/nginx", "/var/www"]
 
 ENTRYPOINT ["nginx", "-g", "daemon off;"]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Docker file for Deluge using Alpine linux
 
-
 ### Build from Dockerfile :
 
 ```bash
@@ -16,7 +15,6 @@ docker build -t shakarang/nginx-alpine .
 Available ports are :
 
 - 80
-
 - 443
 
 ### Volumes :
@@ -24,16 +22,10 @@ Available ports are :
 You can bind multiple volumes :
 
 - /etc/nginx/sites-enabled
-
 - /etc/nginx/certs
-
 - /etc/nginx/conf.d
-
 - /var/log/nginx
-
-- /var/www/html
-
-- /var/www/404/
+- /var/www
 
 ### Running :
 
@@ -44,14 +36,13 @@ nginx:
   container_name: nginx-alpine
   image: shakarang/nginx-alpine
   ports:
-    - 83:80
-    - 444:443
+    - 8080:80
+    - 4443:443
   volumes:
     - ./nginx/sites-enabled:/etc/nginx/sites-enabled
     - ./nginx/certs:/etc/nginx/certs
     - ./nginx/conf.d:/etc/nginx/conf.d
     - ./nginx/log:/var/log/nginx
-    - ./nginx/www/html:/var/www/html
-    - ./nginx/www/404:/var/www/404/
+    - ./nginx/www:/var/www
   restart: always
 ```


### PR DESCRIPTION
I removed `"/var/www/html"` and `"/var/www/404/"` to replace them by `"/var/www"` in Dockerfile.

What do you think?
